### PR TITLE
add sharding for distributed execution

### DIFF
--- a/spotify_tensorflow/dataset.py
+++ b/spotify_tensorflow/dataset.py
@@ -21,6 +21,8 @@ from __future__ import absolute_import, division, print_function
 import multiprocessing as mp
 
 import tensorflow as tf
+import os
+import json
 from tensorflow.python.lib.io import file_io
 
 
@@ -122,6 +124,20 @@ class Datasets(object):
         num_features, parse_fn = Datasets.get_parse_proto_function(feature_desc_path,
                                                                    feature_mapping_fn)
         dataset = tf.data.Dataset.from_tensor_slices(filenames)
+
+        tf_config = os.environ.get('TF_CONFIG')
+
+        # If TF_CONFIG is not available don't bother sharding
+        if tf_config is not None:
+            tf_config_json = json.loads(tf_config)
+            tf.logging.info('we have a TF_CONFIG: %s' % tf_config)
+            num_workers = len(tf_config_json.get('cluster',{}).get('worker',[]))
+            tf.logging.info('num_workers=%s' % num_workers)
+            worker_index = tf_config_json.get('task', {}).get('index', None)
+            tf.logging.info('sharding on worker_index=%s' % worker_index)
+            if worker_index is not None:
+                dataset = dataset.shard(num_workers, worker_index)
+
         # TODO(rav): does `map` need to be inside `interleave`, what are the performance diff?
         dataset = dataset.interleave(lambda f: tf.data.TFRecordDataset(f, compression_type),
                                      cycle_length=num_threads,

--- a/spotify_tensorflow/dataset.py
+++ b/spotify_tensorflow/dataset.py
@@ -18,11 +18,11 @@
 
 from __future__ import absolute_import, division, print_function
 
+import json
 import multiprocessing as mp
+import os
 
 import tensorflow as tf
-import os
-import json
 from tensorflow.python.lib.io import file_io
 
 
@@ -125,17 +125,17 @@ class Datasets(object):
                                                                    feature_mapping_fn)
         dataset = tf.data.Dataset.from_tensor_slices(filenames)
 
-        tf_config = os.environ.get('TF_CONFIG')
+        tf_config = os.environ.get("TF_CONFIG")
 
         # If TF_CONFIG is not available don't bother sharding
         if tf_config is not None:
             tf_config_json = json.loads(tf_config)
-            tf.logging.info('we have a TF_CONFIG: %s' % tf_config)
-            num_workers = len(tf_config_json.get('cluster',{}).get('worker',[]))
-            tf.logging.info('num_workers=%s' % num_workers)
-            worker_index = tf_config_json.get('task', {}).get('index', None)
-            tf.logging.info('sharding on worker_index=%s' % worker_index)
+            tf.logging.info("Found TF_CONFIG: %s" % tf_config)
+            num_workers = len(tf_config_json.get("cluster", {}).get("worker", []))
+            worker_index = tf_config_json.get("task", {}).get("index", None)
             if worker_index is not None:
+                tf.logging.info("Sharding dataset on worker_index=%s out of %s workers"
+                                % (worker_index, num_workers))
                 dataset = dataset.shard(num_workers, worker_index)
 
         # TODO(rav): does `map` need to be inside `interleave`, what are the performance diff?


### PR DESCRIPTION
This prevents processing the entire dataset on each worker. The execution profile is still a bit mysterious as many workers will progressively finish doing work and go idle, up to a point they are all idle and the master alone is left processing the remaining batches. Certainly a decent starting point to further our understanding.