### PR TITLE
Method to freeze a TF graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ target/
 *.swp
 AUTHORS
 ChangeLog
+.DS_Store

--- a/spotify_tensorflow/freeze_graph.py
+++ b/spotify_tensorflow/freeze_graph.py
@@ -1,3 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Spotify AB.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 import logging
 
 import tensorflow as tf

--- a/spotify_tensorflow/freeze_graph.py
+++ b/spotify_tensorflow/freeze_graph.py
@@ -1,0 +1,55 @@
+import logging
+
+import tensorflow as tf
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class FreezeGraph(object):
+
+    @classmethod
+    def freeze_graph_session(session, path, network):
+        """
+        Freeze a graph by taking a session and a network and storing
+        the results into a pb file at the given path. This function wil convert
+        variables to constants which is necessary for JVM serving.
+
+        :param session: TF Session
+        :param path: Where the graph will be written
+        :param network: Tensor representing a network(Usually a prediction)
+        :return: Path to the written graph
+        """
+        input_graph_def = tf.get_default_graph().as_graph_def()
+
+        logger.info("Freezing model")
+        output_node_names = [t.op.name for t in [network]]
+
+        output_graph_def = tf.graph_util.convert_variables_to_constants(
+            session,
+            input_graph_def,
+            output_node_names,
+            variable_names_blacklist=['global_step']
+        )
+
+        with tf.gfile.GFile(path, "wb") as f:
+            f.write(output_graph_def.SerializeToString())
+
+        return path
+
+    @classmethod
+    def freeze_graph_checkpoint(cls, checkpoint, path, network):
+        """
+        Freeze a graph by taking a checkpoint and a network and storing
+        the results into a pb file at the given path. This function wil convert
+        variables to constants which is necessary for JVM serving.
+
+        :param checkpoint: Path to a local checkpoint file
+        :param path: Where the graph will be written
+        :param network: Tensor representing a network(Usually a prediction)
+        :return: Path to the written graph
+        """
+        with tf.Session(graph=tf.Graph()) as sess:
+            saver = tf.train.import_meta_graph(checkpoint + '.meta', clear_devices=True)
+            saver.restore(sess, checkpoint)
+            return cls.freeze_graph_session(sess, path, network)

--- a/spotify_tensorflow/freeze_graph.py
+++ b/spotify_tensorflow/freeze_graph.py
@@ -29,7 +29,7 @@ class FreezeGraph(object):
             session,
             input_graph_def,
             output_node_names,
-            variable_names_blacklist=['global_step']
+            variable_names_blacklist=["global_step"]
         )
 
         with tf.gfile.GFile(path, "wb") as f:
@@ -50,6 +50,6 @@ class FreezeGraph(object):
         :return: Path to the written graph
         """
         with tf.Session(graph=tf.Graph()) as sess:
-            saver = tf.train.import_meta_graph(checkpoint + '.meta', clear_devices=True)
+            saver = tf.train.import_meta_graph(checkpoint + ".meta", clear_devices=True)
             saver.restore(sess, checkpoint)
             return cls.freeze_graph_session(sess, path, network)

--- a/spotify_tensorflow/freeze_graph.py
+++ b/spotify_tensorflow/freeze_graph.py
@@ -27,7 +27,7 @@ logger.setLevel(logging.INFO)
 class FreezeGraph(object):
 
     @classmethod
-    def freeze_graph_session(session, path, network):
+    def session(cls, session, path, network):
         """
         Freeze a graph by taking a session and a network and storing
         the results into a pb file at the given path. This function wil convert
@@ -56,7 +56,7 @@ class FreezeGraph(object):
         return path
 
     @classmethod
-    def freeze_graph_checkpoint(cls, checkpoint, path, network):
+    def checkpoint(cls, checkpoint, path, network):
         """
         Freeze a graph by taking a checkpoint and a network and storing
         the results into a pb file at the given path. This function wil convert
@@ -70,4 +70,4 @@ class FreezeGraph(object):
         with tf.Session(graph=tf.Graph()) as sess:
             saver = tf.train.import_meta_graph(checkpoint + ".meta", clear_devices=True)
             saver.restore(sess, checkpoint)
-            return cls.freeze_graph_session(sess, path, network)
+            return cls.session(sess, path, network)

--- a/tests/freeze_test.py
+++ b/tests/freeze_test.py
@@ -19,7 +19,6 @@ import os
 import tempfile
 
 import tensorflow as tf
-
 from spotify_tensorflow.freeze_graph import FreezeGraph
 
 

--- a/tests/freeze_test.py
+++ b/tests/freeze_test.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+#  Copyright 2017 Spotify AB.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+import os
+import tempfile
+
+import tensorflow as tf
+
+from spotify_tensorflow.freeze_graph import FreezeGraph
+
+
+class FreezeTest(tf.test.TestCase):
+
+    def test_freeze_session(self):
+        output_file = tempfile.NamedTemporaryFile(delete=True).name
+        with self.test_session() as sess:
+            x = tf.square([2, 3])
+            FreezeGraph.session(sess, output_file, x)
+            self.assertTrue(os.path.isfile(output_file))

--- a/tests/freeze_test.py
+++ b/tests/freeze_test.py
@@ -40,7 +40,7 @@ class FreezeTest(tf.test.TestCase):
 
     def test_read_freeze_session(self):
         with self.test_session():
-            with gfile.FastGFile(self.output_file, 'rb') as f:
+            with gfile.FastGFile(self.output_file, "rb") as f:
                 graph_def = tf.GraphDef()
                 graph_def.ParseFromString(f.read())
                 tf.import_graph_def(graph_def)

--- a/tests/freeze_test.py
+++ b/tests/freeze_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-#  Copyright 2017 Spotify AB.
+#  Copyright 2018 Spotify AB.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -15,18 +15,32 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+from __future__ import absolute_import, division, print_function
+
 import os
 import tempfile
 
 import tensorflow as tf
 from spotify_tensorflow.freeze_graph import FreezeGraph
+from tensorflow.python.platform import gfile
 
 
 class FreezeTest(tf.test.TestCase):
+    def setUp(self):
+        self.output_file = tempfile.NamedTemporaryFile(delete=False).name
+
+    def tearDown(self):
+        os.unlink(self.output_file)
 
     def test_freeze_session(self):
-        output_file = tempfile.NamedTemporaryFile(delete=True).name
         with self.test_session() as sess:
             x = tf.square([2, 3])
-            FreezeGraph.session(sess, output_file, x)
-            self.assertTrue(os.path.isfile(output_file))
+            FreezeGraph.session(sess, self.output_file, x)
+            self.assertTrue(os.path.isfile(self.output_file))
+
+    def test_read_freeze_session(self):
+        with self.test_session():
+            with gfile.FastGFile(self.output_file, 'rb') as f:
+                graph_def = tf.GraphDef()
+                graph_def.ParseFromString(f.read())
+                tf.import_graph_def(graph_def)


### PR DESCRIPTION
TF has a few different methods to store a graph but the JVM library in particular requires a special format of a single pb file where the variables are converted to a constant within that pb file.  This requires calling `convert_variables_to_constants` and freezing the graph.

This PR provides a way to freeze a graph either from a current session or a checkpoint file.  The session is useful for tasks using session API while the checkpoint can be used easily from the Estimator API.

```python
estimator = tf.estimator.Estimator(...)
estimator.train(input_fn=train_input_fn)
feature = tf.placeholder(tf.float32, [None, n_features], name="input")
FreezeGraph.freeze_graph_checkpoint(estimator.latest_checkpoint(), output_path, graph(feature))
```