### PR TITLE
Make featran dataset method public.

### DIFF
--- a/spotify_tensorflow/dataset.py
+++ b/spotify_tensorflow/dataset.py
@@ -57,11 +57,11 @@ class DatasetContext(namedtuple("DatasetContext", ["filenames",
 class Datasets(object):
 
     @classmethod
-    def _get_featran_example_dataset(cls,
-                                     dir_path,  # type: str
-                                     feature_mapping_fn=None,  # type: Callable[[List[FeatureInfo]], OrderedDict[str, Union[tf.FixedLenFeature, tf.VarLenFeature]]]  # noqa: E501
-                                     tf_record_spec_path=None  # type: str
-                                     ):
+    def get_featran_example_dataset(cls,
+                                    dir_path,  # type: str
+                                    feature_mapping_fn=None,  # type: Callable[[List[FeatureInfo]], OrderedDict[str, Union[tf.FixedLenFeature, tf.VarLenFeature]]]  # noqa: E501
+                                    tf_record_spec_path=None  # type: str
+                                    ):
         # type: (...) -> Tuple[tf.data.Dataset, DatasetContext]
         """Get `Dataset` of parsed `Example` protos.
 
@@ -183,8 +183,8 @@ class Datasets(object):
             object.
         """
         with tf.name_scope(scope):
-            dataset, context = cls._get_featran_example_dataset(data_dir,
-                                                                feature_mapping_fn)
+            dataset, context = cls.get_featran_example_dataset(data_dir,
+                                                               feature_mapping_fn)
             if FLAGS["shuffle-buffer-size"] > 0:
                 dataset = dataset.shuffle(FLAGS["shuffle-buffer-size"])
 

--- a/spotify_tensorflow/dataset.py
+++ b/spotify_tensorflow/dataset.py
@@ -210,7 +210,7 @@ class Datasets(object):
                          take=sys.maxsize,  # type: int
                          feature_mapping_fn=None  # type: Callable[[List[FeatureInfo]], OrderedDict[str, Union[tf.FixedLenFeature, tf.VarLenFeature]]]  # noqa: E501
                          ):
-            # type: (...) -> Dict[str, np.ndarray]
+            # type: (...) -> Optional[Dict[str, np.ndarray]]
             """
             Read a TF dataset and load it into a Dictionary of Numpy Arrays.
 
@@ -227,7 +227,7 @@ class Datasets(object):
                            batch_size=10000,  # type: int
                            feature_mapping_fn=None  # type: Callable[[List[FeatureInfo]], OrderedDict[str, Union[tf.FixedLenFeature, tf.VarLenFeature]]]  # noqa: E501
                            ):
-            # type: (...) -> Iterator[Dict[str, np.ndarray]]
+            # type: (...) -> Iterator[Optional[Dict[str, np.ndarray]]]
             """
             Read a TF dataset in batches, each one yielded as a Dictonary.
 
@@ -253,10 +253,10 @@ class Datasets(object):
                 self.batch_size = batch_size
                 self.batch_iter = training_it.get_next()
                 self.context = context
-                self.buff = None  # type: OrderedDict[str, np.ndarray]
+                self.buff = None  # type: Optional[OrderedDict[str, np.ndarray]]
 
             def __iter__(self):
-                # type: () -> Iterator[OrderedDict[str, np.ndarray]]
+                # type: () -> Iterator[Optional[OrderedDict[str, np.ndarray]]]
                 logger.info("Starting TF Session...")
                 with tf.Session() as sess:
                     logger.info("Reading TFRecords...")
@@ -289,7 +289,7 @@ class Datasets(object):
                     return v1.append(v2)
 
             def _get_batch(self, sess):
-                # type: (tf.Session) -> OrderedDict[str, np.ndarray]
+                # type: (tf.Session) -> Optional[OrderedDict[str, np.ndarray]]
                 if self.buff is None:
                     self.buff = OrderedDict()
                     first_result = sess.run(self.batch_iter)
@@ -363,10 +363,13 @@ class Datasets(object):
 
         @staticmethod
         def __format_df(batch, multispec_feature_groups):
-            # type: (Dict[str, np.ndarray], Optional[List[List[str]]]) -> Union[pd.DataFrame, List[pd.DataFrame]]  # noqa: E501
+            # type: (Optional[Dict[str, np.ndarray]], Optional[List[List[str]]]) -> Union[pd.DataFrame, List[pd.DataFrame]]  # noqa: E501
             df = pd.DataFrame(batch)
             if not multispec_feature_groups:
-                return df[list(batch.keys())]
+                if batch:
+                    return df[list(batch.keys())]
+                else:
+                    return df[list({})]
             return [df[f] for f in multispec_feature_groups]
 
     dataframe = __DataFrameEndpoint()

--- a/spotify_tensorflow/tf_record_spec_parser.py
+++ b/spotify_tensorflow/tf_record_spec_parser.py
@@ -18,7 +18,7 @@
 
 import json
 from collections import OrderedDict, namedtuple
-from typing import Tuple, Text, List  # noqa: F401
+from typing import Tuple, Text, List, Optional  # noqa: F401
 
 import six
 import tensorflow as tf
@@ -31,7 +31,7 @@ class TfRecordSpecParser(object):
     # TODO: make this private, or handle arguments better, having both of the required doesn't make sense # noqa: E501
     @classmethod
     def parse_tf_record_spec(cls,
-                             tf_record_desc_path,  # type: str
+                             tf_record_desc_path,  # type: Optional[str]
                              dir_path  # type: str
                              ):
         # type: (...) -> Tuple[List[FeatureInfo], str, List[List[str]]]
@@ -82,7 +82,7 @@ class TfRecordSpecParser(object):
         return feature_info, compression_map[spec["compression"]], multispec_feature_groups
 
     @staticmethod
-    def __get_tf_record_spec_path(tf_record_desc_path,  # type: str
+    def __get_tf_record_spec_path(tf_record_desc_path,  # type: Optional[str]
                                   dir_path  # type: str
                                   ):
         # type: (...) -> Text

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -62,7 +62,7 @@ class SquareTest(tf.test.TestCase):
     def test_get_featran_example_dataset(self):
         d, _, _ = DataUtil.write_featran_test_data()
         with self.test_session() as sess:
-            dataset, c = Datasets._get_featran_example_dataset(d)
+            dataset, c = Datasets.get_featran_example_dataset(d)
             self.assertEquals(len(c.features), 2)
             iterator = dataset.make_one_shot_iterator()
             r = iterator.get_next()


### PR DESCRIPTION
`Datasets.mk_iter()` relies on flags to set things like batch_size, shuffle etc on the dataset, however since it's common to have different values for the training + evaluation datasets, they can't share those flags. In that case people should drop down a level and operate on the dataset directly - hence making this method public.