### PR TITLE
Tensorflow: 1.9.0 => 1.10.1

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-tensorflow==1.9.0
+tensorflow==1.10.1
 coverage
 flake8>=3.4.1
 flake8-quotes>=0.12.0


### PR DESCRIPTION
Inspired by the CI failure @fallonchen saw when upgrading straight to 1.11.x in #80 I was able to reproduce the test failure locally and bisected it down to the 1.10.1 => 1.11.0rc0 bump.

Should be a bit easier to find the cause of the segfault with this smaller surface area.