### PR TITLE
coverage: ignore deprecated ExternalDailySnapshot

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,29 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "header, diff"
+  behavior: default
+  require_changes: no
+
 ignore:
   - "**/external_daily_snapshot.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "**/external_daily_snapshot.py"


### PR DESCRIPTION
This deprecated class will be going away shortly anyway. No sense in copying the tests from `luigi.contrib`. Let's just ignore this class for the purposes of calculating test coverage.

In service of #94.