### PR TITLE
tfr-read: move to main code tree

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,10 @@ packages =
 tensorflow = tensorflow==1.9.0
 tensorflow_gpu = tensorflow-gpu==1.9.0
 
+[entry_points]
+console_scripts =
+    tfr-read = spotify_tensorflow.scripts.tfr_read:main
+
 [global]
 tests_require =
     tox>=3.0.0

--- a/setup.py
+++ b/setup.py
@@ -17,4 +17,4 @@
 #  under the License.
 from setuptools import setup
 
-setup(setup_requires=["pbr"], pbr=True, scripts=["bin/tfr-read"])
+setup(setup_requires=["pbr"], pbr=True)

--- a/spotify_tensorflow/scripts/__init__.py
+++ b/spotify_tensorflow/scripts/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Spotify AB.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#

--- a/spotify_tensorflow/scripts/tfr_read.py
+++ b/spotify_tensorflow/scripts/tfr_read.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 #  Copyright 2018 Spotify AB.
@@ -72,7 +71,7 @@ def list_tf_records(paths, default_schema):
             yield f, dir_schemas[os.path.dirname(f)]
 
 
-if __name__ == "__main__":
+def main():
     cmdline_args = get_args()
 
     default_schema = None
@@ -105,3 +104,7 @@ if __name__ == "__main__":
                 if e.errno == errno.EPIPE:
                     sys.exit(0)
                 raise e
+
+
+if __name__ == "__main__":
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ deps = -r{toxinidir}/test-requirements.txt
 commands =
   nosetests
   flake8 spotify_tensorflow
-  flake8 bin/tfr-read
   flake8 examples
   flake8 tests
   {toxinidir}/bin/run-examples


### PR DESCRIPTION
No reason for `tfr-read` to be a special snowflake. Prefer to have it included with other code for easier dev and to be included with test coverage calculation.