### PR TITLE
build: coverage was broken by 8475791

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,35 +20,32 @@ jobs:
   lint:
     executor: tox
     steps:
-      - tox: {env: lint}
+      - tox: {env: "lint"}
 
   test-tf18:
     executor: tox
     steps:
-      - tox: {env: test-tf18}
+      - tox: {env: "test-tf18"}
 
   test-tf19:
     executor: tox
     steps:
-      - tox: {env: test-tf19}
+      - tox: {env: "test-tf19"}
 
   test:
     executor: tox
     steps:
-      - tox: {env: test}
-      - run: |
-          pip install --user codecov
-          python -m codecov
+      - tox: {env: "test,upload-coverage"}
 
   examples:
     executor: tox
     steps:
-      - tox: {env: examples}
+      - tox: {env: "examples"}
 
   mypy:
     executor: tox
     steps:
-      - tox: {env: mypy}
+      - tox: {env: "mypy"}
 
 workflows:
   version: 2

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.3.0
-envlist = mypy,lint,examples,test,test-tf{18, 19, 110, 111, 112}
+envlist = mypy,lint,examples,test,test-tf{18, 19, 110, 111, 112},upload-coverage
 
 [testenv]
 basepython = python2.7
@@ -45,3 +45,12 @@ deps =
 commands =
   mypy spotify_tensorflow
   mypy tests
+
+[testenv:upload-coverage]
+extras =
+deps =
+  codecov
+setenv =
+  CODECOV_TOKEN = fdca8927-392d-4daa-b5ec-2de46127cf70
+commands =
+  python -m codecov


### PR DESCRIPTION
Because upload of coverage.xml was moved to a separate build step from the tests, it was no longer present when the upload was attempted.

PRs have been missing coverage metrics.