### PR TITLE
tests: run nosetest in verbose mode

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist = mypy,lint,examples,test,test-tf{18, 19, 110, 111, 112},upload-coverage
 basepython = python2.7
 commands =
   python -c "import tensorflow as tf; print tf.__version__"
-  nosetests
+  nosetests -vv
 extras =
   testing
   tfx


### PR DESCRIPTION
With these verbose flags we get the full test names instead of simply `.` for each test. This is useful in debugging.