### PR TITLE
extras: drop tensorflow-gpu

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,8 +22,6 @@ packages =
     spotify_tensorflow
 
 [extras]
-tensorflow_gpu =
-    tensorflow-gpu==1.9.0
 tfx =
     luigi>=2.3.3,<3.0.0
     google-api-python-client>=1.5.4,<2.0


### PR DESCRIPTION
Users should feel free to add this themselves. Currently, there are no
internal usages of this particular extra.