### PR TITLE
Remove auto generated tft requirements file

### DIFF
--- a/spotify_tensorflow/luigi/python_dataflow_task.py
+++ b/spotify_tensorflow/luigi/python_dataflow_task.py
@@ -53,6 +53,7 @@ class PythonDataflowTask(MixinNaiveBulkComplete, luigi.Task):
     requirements_file = None        # Path to a requirements file containing package dependencies.
     local_runner = False            # If local_runner = True, the job uses DirectRunner,
                                       otherwise it uses DataflowRunner
+    setup_file = None               # Path to a setup Python file containing package dependencies.
 
     :Example:
 
@@ -91,6 +92,7 @@ class PythonDataflowTask(MixinNaiveBulkComplete, luigi.Task):
     job_name = None  # type: str
     requirements_file = None  # type: str
     local_runner = False  # type: bool
+    setup_file = None  # type: str
 
     def __init__(self, *args, **kwargs):
         super(PythonDataflowTask, self).__init__(*args, **kwargs)
@@ -258,6 +260,8 @@ class PythonDataflowTask(MixinNaiveBulkComplete, luigi.Task):
             dataflow_args += ["--service_account_email={}".format(self.service_account)]
         if self.requirements_file:
             dataflow_args += ["--requirements_file={}".format(self.requirements_file)]
+        if self.setup_file:
+            dataflow_args += ["--setup_file={}".format(self.setup_file)]
 
         return dataflow_args
 

--- a/spotify_tensorflow/tfx/tft.py
+++ b/spotify_tensorflow/tfx/tft.py
@@ -32,8 +32,7 @@ from apache_beam.io.filesystem import CompressionTypes
 from apache_beam.io.filesystems import FileSystems
 from apache_beam.runners import PipelineState  # noqa: F401
 from spotify_tensorflow.tf_schema_utils import schema_txt_file_to_feature_spec
-from spotify_tensorflow.tfx.utils import assert_not_empty_string, construct_tft_reqs_txt, \
-    assert_not_none
+from spotify_tensorflow.tfx.utils import assert_not_empty_string, assert_not_none
 from tensorflow_transform.beam import impl as beam_impl
 from tensorflow_transform.beam.tft_beam_io import transform_fn_io
 from tensorflow_transform.coders import ExampleProtoCoder
@@ -72,10 +71,6 @@ class TFTransform(object):
             required=False,
             help="path to the saved transform function")
         parser.add_argument(
-            "--requirements_file",
-            required=False,
-            help="path to the requirements file we would like installed on the Dataflow workers")
-        parser.add_argument(
             "--compression_type",
             required=False,
             help="compression type for writing of tf.records")
@@ -84,14 +79,8 @@ class TFTransform(object):
             args = sys.argv[1:]
         tft_args, pipeline_args = parser.parse_known_args(args=args)
 
-        if tft_args.requirements_file is None:
-            reqs_file = construct_tft_reqs_txt()
-        else:
-            reqs_file = tft_args.requirements_file
-
         # pipeline_args also needs temp_location and requirements_file
         pipeline_args.append("--temp_location=%s" % tft_args.temp_location)
-        pipeline_args.append("--requirements_file=%s" % reqs_file)
 
         tftransform(pipeline_args=pipeline_args,
                     temp_location=tft_args.temp_location,

--- a/spotify_tensorflow/tfx/utils.py
+++ b/spotify_tensorflow/tfx/utils.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-import tempfile
 from typing import Any  # noqa: F401
 
 
@@ -31,16 +30,3 @@ def assert_not_empty_string(arg):
         raise TypeError("Argument should be a string")
     if arg == "":
         raise ValueError("Argument can't be an empty string")
-
-
-def construct_tft_reqs_txt():
-    # type: () -> str
-    tf_metadata_version = "0.9.0"
-    tf_transform_version = "0.9.0"
-
-    with tempfile.NamedTemporaryFile("w", delete=False) as tft_reqs_txt:
-        tft_reqs_txt.writelines([
-            "tensorflow-transform=={}\n".format(tf_transform_version),
-            "tensorflow-metadata=={}\n".format(tf_metadata_version)
-        ])
-        return tft_reqs_txt.name

--- a/tests/python_dataflow_task_test.py
+++ b/tests/python_dataflow_task_test.py
@@ -48,6 +48,7 @@ class DummyPythonDataflowTask(PythonDataflowTask):
     disk_size_gb = 30
     worker_disk_type = "disc_type"
     job_name = "dummy"
+    setup_file = "setup.py"
 
     def requires(self):
         return {"input": DummyRawFeature()}
@@ -102,7 +103,8 @@ class PythonDataflowTaskTest(TestCase):
             "--worker_disk_type=disc_type",
             "--job_name=dummy",
             "--zone=zone",
-            "--region=region"
+            "--region=region",
+            "--setup_file=setup.py"
         ]
         actual = task._mk_cmd_line()
         self.assertEquals(actual[:2], expected[:2])


### PR DESCRIPTION
If we are using setup.py or bundle tfx requires with sp-tensorflow, we'll not need separate requirements file for tft beam job