### PR TITLE
Move tensorflow-transform to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ oauth2client<4.0.0
 pandas>=0.22.0,<1.0.0
 six>=1.11.0,<2.0.0
 tensorflow>=1.9.0,<1.11; python_version=='2.7'
+tensorflow-transform==0.9.0; python_version=='2.7'
 tensorflow_metadata==0.9.0
 typing>=3.6.4,<4.0.0
 requests==2.19.1 # for tfdv only

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,6 @@ packages =
 [extras]
 tfx =
     tensorflow-data-validation==0.11.0
-    tensorflow-transform==0.9.0
 examples =
     scipy
     sklearn


### PR DESCRIPTION
Dataset api now uses tft schema utils, so we should at least include it in the requirements.txt file. 

Also created an issue to capture the future work. We may want to reorganize requirements.txt to have all tf related libs.  https://github.com/spotify/spotify-tensorflow/issues/148 