### PR TITLE
reqs: Upgrade tensorflow 1.{10=>11}

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,16 @@ jobs:
     steps:
       - tox: {env: "test-tf19"}
 
+  test-tf110:
+    executor: tox
+    steps:
+      # Note: We'd prefer to `upload-coverage` alongside the
+      # more usual `test` testenv, but because of the isolated
+      # test workaround (see `tox.ini`) we're not able to compute
+      # coverage for tensorflow versions 1.11.x and 1.12.x.
+      # Once we upgrade to >=1.13.x, we can switch back.
+      - tox: {env: "test-tf110,upload-coverage"}
+
   test-tf111:
     executor: tox
     steps:
@@ -40,7 +50,7 @@ jobs:
   test:
     executor: tox
     steps:
-      - tox: {env: "test,upload-coverage"}
+      - tox: {env: "test"}
 
   examples:
     executor: tox
@@ -58,6 +68,7 @@ workflows:
     jobs:
       - lint
       - test-tf19
+      - test-tf110
       - test-tf111
       - test-tf112
       - test

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ numpy>=1.14.0,<2.0.0
 oauth2client<4.0.0
 pandas>=0.22.0,<1.0.0
 six>=1.11.0,<2.0.0
-tensorflow>=1.9.0,<1.11; python_version=='2.7'
-tensorflow-transform==0.9.0; python_version=='2.7'
+tensorflow>=1.9.0,<1.12; python_version=='2.7'
+tensorflow-transform==0.11.0; python_version=='2.7'
 tensorflow_metadata==0.9.0
 typing>=3.6.4,<4.0.0
 requests==2.19.1 # for tfdv only

--- a/tox.ini
+++ b/tox.ini
@@ -15,12 +15,21 @@ extras =
 [testenv:test-tf19]
 commands =
   pip install --quiet tensorflow==1.9.0
+  pip install --quiet tensorflow_transform==0.9.0
   {[testenv]commands}
 
 [testenv:test-tf110]
 commands =
   pip install --quiet tensorflow==1.10.0
+  pip install --quiet tensorflow_transform==0.9.0
   {[testenv]commands}
+
+[testenv:test]
+commands =
+  pip install --quiet tensorflow==1.11.0
+  /usr/bin/find . -name "*.pyc" -delete
+  python -c "import tensorflow as tf; print tf.__version__"
+  {toxinidir}/bin/run-isolated-tests
 
 [testenv:test-tf111]
 commands =
@@ -49,6 +58,7 @@ extras =
   examples
   tfx
 commands =
+  python -c "import tensorflow as tf; print tf.__version__"
   {toxinidir}/bin/run-examples
 
 [testenv:mypy]


### PR DESCRIPTION
Note: I'm leaving the redundant `test-tf110`. The `test` env can continue to float without us worrying.