### PR TITLE
Datasets.parse_schema supports pbtxt

### DIFF
--- a/spotify_tensorflow/tf_schema_utils.py
+++ b/spotify_tensorflow/tf_schema_utils.py
@@ -38,6 +38,14 @@ def parse_schema_file(schema_path):  # type: (str) -> Schema
     """
     Read a schema file and return the proto object.
     """
+    return parse_schema_txt_file(schema_path) if schema_path.endswith("txt") \
+        else parse_schema_pb_file(schema_path)
+
+
+def parse_schema_pb_file(schema_path):  # type (str) -> Schema
+    """
+    Parse a binary tf.metadata Schema file into its in-memory representation.
+    """
     assert file_io.file_exists(schema_path), "File not found: {}".format(schema_path)
     schema = Schema()
     with file_io.FileIO(schema_path, "rb") as f:
@@ -67,16 +75,8 @@ def schema_to_feature_spec(schema):
 def schema_file_to_feature_spec(schema_path):
     # type: (str) -> Dict[str, Union[tf.FixedLenFeature, tf.VarLenFeature, tf.SparseFeature]]
     """
-    Convert a serialized tf.metadata Schema file to a Tensorflow feature_spec object
+    Convert a serialized tf.metadata Schema file (binary or text) to a Tensorflow feature_spec
+    object
     """
     schema = parse_schema_file(schema_path)
-    return schema_to_feature_spec(schema)
-
-
-def schema_txt_file_to_feature_spec(schema_path):
-    # type: (str) -> Dict[str, Union[tf.FixedLenFeature, tf.VarLenFeature, tf.SparseFeature]]
-    """
-    Convert a tf.metadata Schema text file to a TensorFlow feature_spec object.
-    """
-    schema = parse_schema_txt_file(schema_path)
     return schema_to_feature_spec(schema)

--- a/spotify_tensorflow/tfx/tft.py
+++ b/spotify_tensorflow/tfx/tft.py
@@ -31,7 +31,7 @@ from apache_beam.io import tfrecordio
 from apache_beam.io.filesystem import CompressionTypes
 from apache_beam.io.filesystems import FileSystems
 from apache_beam.runners import PipelineState  # noqa: F401
-from spotify_tensorflow.tf_schema_utils import schema_txt_file_to_feature_spec
+from spotify_tensorflow.tf_schema_utils import schema_file_to_feature_spec
 from spotify_tensorflow.tfx.utils import assert_not_empty_string, assert_not_none
 from tensorflow_transform.beam import impl as beam_impl
 from tensorflow_transform.beam.tft_beam_io import transform_fn_io
@@ -109,7 +109,7 @@ def tftransform(pipeline_args,                          # type: List[str]
 
     :param pipeline_args: un-parsed Dataflow arguments
     :param temp_location: temporary location for dataflow job working dir
-    :param schema_file: path to the raw feature schema text file
+    :param schema_file: path to the raw feature schema file (text or binary)
     :param output_dir: output dir for transformed data and function
     :param preprocessing_fn: tf.transform preprocessing function
     :param training_data: path to the training data
@@ -126,7 +126,7 @@ def tftransform(pipeline_args,                          # type: List[str]
     if compression_type is None:
         compression_type = CompressionTypes.AUTO
 
-    raw_feature_spec = schema_txt_file_to_feature_spec(schema_file)
+    raw_feature_spec = schema_file_to_feature_spec(schema_file)
     raw_schema = dataset_schema.from_feature_spec(raw_feature_spec)
     raw_data_metadata = dataset_metadata.DatasetMetadata(raw_schema)
     raw_data_coder = ExampleProtoCoder(raw_data_metadata.schema)


### PR DESCRIPTION
It's common to have a schema checked into version control. This change
makes it transparent to use either binary or text format.