### PR TITLE
Combine GenerateStats and TfDataValidator

### DIFF
--- a/spotify_tensorflow/tfx/tfdv.py
+++ b/spotify_tensorflow/tfx/tfdv.py
@@ -16,49 +16,93 @@
 # under the License.
 #
 
+import logging
 import os
-import sys
 import time
+from os.path import join as pjoin
+from typing import List  # noqa: F401
 
 import tensorflow_data_validation as tfdv
 from apache_beam.options.pipeline_options import GoogleCloudOptions, PipelineOptions, SetupOptions
 from spotify_tensorflow.tfx.utils import create_setup_file, assert_not_empty_string
+from spotify_tensorflow.tf_schema_utils import parse_schema_txt_file
 from tensorflow_metadata.proto.v0 import statistics_pb2  # noqa: F401
 from tensorflow.python.lib.io import file_io
 
+logger = logging.getLogger("spotify-tensorflow")
 
-class GenerateStats(object):
-    def __init__(self, input_data, output_path=None):
-        self.input_data = input_data
-        if output_path is None:
-            self.output_path = os.path.join(self.input_data, "stats.pb")
-        else:
-            self.output_path = output_path
 
-    def run(self, pipeline_args=None):
-        if pipeline_args is None:
-            pipeline_args = sys.argv[1:]
+class TfDataValidator(object):
+    """Spotify-specific API for using Tensorflow Data Valiation in production.
+
+    The typical usage is to create an instance of this class from a Luigi task that produces
+    tfrecord files in order to produce statistics, a schema snapshot and any anomalies along with
+    the dataset.
+    """
+
+    def __init__(self,
+                 schema_path,  # type: str
+                 data_location,  # type: str
+                 ):
+        """
+        :param schema_path: tf.metadata Schema path. Must be in text format
+        :param data_location: input data dir containing tfrecord files
+        """
+        self.data_location = data_location
+        self.schema = parse_schema_txt_file(schema_path)
+        self.schema_snapshot_path = pjoin(self.data_location, "schema_snapshot.pb")
+        self.stats_path = pjoin(self.data_location, "stats.pb")
+        self.anomalies_path = pjoin(self.data_location, "anomalies.pb")
+
+    def write_stats(self, pipeline_args):
+        # type: (List[str]) -> statistics_pb2.DatasetFeatureStatisticsList
         return generate_statistics_from_tfrecord(pipeline_args=pipeline_args,
-                                                 input_data_dir=self.input_data,
-                                                 output_path=self.output_path)
+                                                 data_location=self.data_location,
+                                                 output_path=self.stats_path)
+
+    def write_stats_and_schema(self, pipeline_args):  # type: (List[str]) -> None
+        self.write_stats(pipeline_args)
+        self.upload_schema()
+
+    def validate_stats_against_schema(self):  # type: () -> bool
+        stats = tfdv.load_statistics(self.stats_path)
+        self.anomalies = tfdv.validate_statistics(stats, self.schema)
+        if len(self.anomalies.anomaly_info.items()) > 0:
+            logger.error("Anomalies found in training dataset...")
+            logger.error(str(self.anomalies.anomaly_info.items()))
+            self.upload_anomalies()
+            return False
+        else:
+            logger.info("No anomalies found")
+            return True
+
+    def upload_schema(self):  # type: () -> None
+        file_io.atomic_write_string_to_file(self.schema_snapshot_path,
+                                            self.schema.SerializeToString())
+
+    def upload_anomalies(self):  # type: () -> None
+        if self.anomalies.anomaly_info:
+            file_io.atomic_write_string_to_file(self.anomalies_path,
+                                                self.anomalies.SerializeToString())
 
 
-def generate_statistics_from_tfrecord(pipeline_args,   # type: str
-                                      input_data_dir,  # type: str
-                                      output_path      # type: str
+def generate_statistics_from_tfrecord(pipeline_args,  # type: List[str]
+                                      data_location,  # type: str
+                                      output_path     # type: str
                                       ):
     # type: (...) ->  statistics_pb2.DatasetFeatureStatisticsList
     """
     Generate stats file from a tfrecord dataset using TFDV
 
     :param pipeline_args: un-parsed Dataflow arguments
-    :param input_data_dir:
-    :param output_path:
-    :return final state of the Beam pipeline
+    :param data_location: input data dir containing tfrecord files
+    :param output_path: output path for the stats file
+    :return a DatasetFeatureStatisticsList proto.
     """
-    assert_not_empty_string(input_data_dir)
+    assert_not_empty_string(data_location)
     assert_not_empty_string(output_path)
 
+    # TODO: convert pipeline_args to snake case here
     pipeline_options = PipelineOptions(flags=pipeline_args)
 
     all_options = pipeline_options.get_all_options()
@@ -72,64 +116,7 @@ def generate_statistics_from_tfrecord(pipeline_args,   # type: str
         setup_options = pipeline_options.view_as(SetupOptions)
         setup_options.setup_file = setup_file_path
 
-    input_files = os.path.join(input_data_dir, "*.tfrecords")
+    input_files = os.path.join(data_location, "*.tfrecords")
     return tfdv.generate_statistics_from_tfrecord(data_location=input_files,
                                                   output_path=output_path,
                                                   pipeline_options=pipeline_options)
-
-
-class TfDataValidator:
-    """Spotify-specific API for using Tensorflow Data Valiation in production.
-
-    The typical usage is to create an instance of this class from a Luigi task that produces
-    tfrecord files in order to produce statistics, a schema snapshot and any anomalies along with
-    the dataset.
-    """
-
-    def __init__(self,
-                 schema_path,  # type: str
-                 data_location,  # type: str
-                 setup_file  # type: str
-                 ):
-        """
-        :param schema_path: tf.metadata Schema path. Must be in text format
-        :param data_location: GCS folder containing tfrecord files
-        :param setup_file: Path to setup.py file containing spotify-tensorflow
-        """
-        self.data_location = data_location
-        self.schema = parse_schema_txt_file(schema_path)
-        self.schema_snapshot_path = pjoin(self.data_location, "schema_snapshot.pb")
-        self.stats_path = pjoin(self.data_location, "stats.pb")
-        self.anomalies_path = pjoin(self.data_location, "anomalies.pb")
-        # TODO: can we move this into lib?
-        self.setup_file = setup_file
-
-    def write_stats_and_schema(self, dataflow_args):  # type: (List[str]) -> None
-        py_pipeline_args = ["=".join([to_snake_case(arg.split("=")[0]),
-                                      arg.split("=")[1]]) for arg in dataflow_args]
-        py_pipeline_args.append("--setup_file=%s" % self.setup_file)
-        tfdv.generate_statistics_from_tfrecord(pjoin(self.data_location, "part-*"),
-                                               output_path=self.stats_path,
-                                               pipeline_options=PipelineOptions(py_pipeline_args))
-        self.upload_schema()
-
-    def validate_stats_against_schema(self):  # type: () -> bool
-        stats = tfdv.load_statistics(self.stats_path)
-        self.anomalies = tfdv.validate_statistics(stats, self.schema).anomaly_info.items()
-        if len(self.anomalies) > 0:
-            logger.error("Anomalies found in training dataset...")
-            logger.error(str(self.anomalies))
-            self.upload_anomalies()
-            return False
-        else:
-            logger.info("No anomalies found")
-            return True
-
-    def upload_schema(self):  # type: () -> None
-        file_io.atomic_write_string_to_file(self.schema_snapshot_path,
-                                            self.schema.SerializeToString())
-
-    def upload_anomalies(self):  # type: () -> None
-        if self.anomalies:
-            file_io.atomic_write_string_to_file(self.anomalies_path,
-                                                self.anomalies.SerializeToString())

--- a/spotify_tensorflow/tfx/tfdv.py
+++ b/spotify_tensorflow/tfx/tfdv.py
@@ -24,7 +24,8 @@ from typing import List  # noqa: F401
 
 import tensorflow_data_validation as tfdv
 from apache_beam.options.pipeline_options import GoogleCloudOptions, PipelineOptions, SetupOptions
-from spotify_tensorflow.tfx.utils import create_setup_file, assert_not_empty_string
+from spotify_tensorflow.tfx.utils import create_setup_file, assert_not_empty_string, \
+    clean_up_pipeline_args
 from spotify_tensorflow.tf_schema_utils import parse_schema_txt_file
 from tensorflow_metadata.proto.v0 import statistics_pb2  # noqa: F401
 from tensorflow.python.lib.io import file_io
@@ -102,8 +103,8 @@ def generate_statistics_from_tfrecord(pipeline_args,  # type: List[str]
     assert_not_empty_string(data_location)
     assert_not_empty_string(output_path)
 
-    # TODO: convert pipeline_args to snake case here
-    pipeline_options = PipelineOptions(flags=pipeline_args)
+    args_in_snake_case = clean_up_pipeline_args(pipeline_args)
+    pipeline_options = PipelineOptions(flags=args_in_snake_case)
 
     all_options = pipeline_options.get_all_options()
 

--- a/spotify_tensorflow/tfx/tfdv.py
+++ b/spotify_tensorflow/tfx/tfdv.py
@@ -24,6 +24,7 @@ import tensorflow_data_validation as tfdv
 from apache_beam.options.pipeline_options import GoogleCloudOptions, PipelineOptions, SetupOptions
 from spotify_tensorflow.tfx.utils import create_setup_file, assert_not_empty_string
 from tensorflow_metadata.proto.v0 import statistics_pb2  # noqa: F401
+from tensorflow.python.lib.io import file_io
 
 
 class GenerateStats(object):
@@ -75,3 +76,60 @@ def generate_statistics_from_tfrecord(pipeline_args,   # type: str
     return tfdv.generate_statistics_from_tfrecord(data_location=input_files,
                                                   output_path=output_path,
                                                   pipeline_options=pipeline_options)
+
+
+class TfDataValidator:
+    """Spotify-specific API for using Tensorflow Data Valiation in production.
+
+    The typical usage is to create an instance of this class from a Luigi task that produces
+    tfrecord files in order to produce statistics, a schema snapshot and any anomalies along with
+    the dataset.
+    """
+
+    def __init__(self,
+                 schema_path,  # type: str
+                 data_location,  # type: str
+                 setup_file  # type: str
+                 ):
+        """
+        :param schema_path: tf.metadata Schema path. Must be in text format
+        :param data_location: GCS folder containing tfrecord files
+        :param setup_file: Path to setup.py file containing spotify-tensorflow
+        """
+        self.data_location = data_location
+        self.schema = parse_schema_txt_file(schema_path)
+        self.schema_snapshot_path = pjoin(self.data_location, "schema_snapshot.pb")
+        self.stats_path = pjoin(self.data_location, "stats.pb")
+        self.anomalies_path = pjoin(self.data_location, "anomalies.pb")
+        # TODO: can we move this into lib?
+        self.setup_file = setup_file
+
+    def write_stats_and_schema(self, dataflow_args):  # type: (List[str]) -> None
+        py_pipeline_args = ["=".join([to_snake_case(arg.split("=")[0]),
+                                      arg.split("=")[1]]) for arg in dataflow_args]
+        py_pipeline_args.append("--setup_file=%s" % self.setup_file)
+        tfdv.generate_statistics_from_tfrecord(pjoin(self.data_location, "part-*"),
+                                               output_path=self.stats_path,
+                                               pipeline_options=PipelineOptions(py_pipeline_args))
+        self.upload_schema()
+
+    def validate_stats_against_schema(self):  # type: () -> bool
+        stats = tfdv.load_statistics(self.stats_path)
+        self.anomalies = tfdv.validate_statistics(stats, self.schema).anomaly_info.items()
+        if len(self.anomalies) > 0:
+            logger.error("Anomalies found in training dataset...")
+            logger.error(str(self.anomalies))
+            self.upload_anomalies()
+            return False
+        else:
+            logger.info("No anomalies found")
+            return True
+
+    def upload_schema(self):  # type: () -> None
+        file_io.atomic_write_string_to_file(self.schema_snapshot_path,
+                                            self.schema.SerializeToString())
+
+    def upload_anomalies(self):  # type: () -> None
+        if self.anomalies:
+            file_io.atomic_write_string_to_file(self.anomalies_path,
+                                                self.anomalies.SerializeToString())

--- a/spotify_tensorflow/tfx/utils.py
+++ b/spotify_tensorflow/tfx/utils.py
@@ -20,6 +20,8 @@ import tempfile
 import textwrap
 from typing import Any  # noqa: F401
 
+from spotify_tensorflow.luigi.utils import to_snake_case
+
 
 def assert_not_none(arg):
     # type: (Any) -> None
@@ -51,3 +53,43 @@ def create_setup_file():
     with open(setup_file_path, "w") as f:
         f.writelines(textwrap.dedent(contents_for_setup_file))
     return setup_file_path
+
+
+def clean_up_pipeline_args(pipeline_args):
+    output_args = list()
+    for arg in pipeline_args:
+        if arg.startswith("--"):
+            if "=" in arg:
+                k, v = arg.split("=")
+                output_args.extend([to_snake_case(k), v])
+            else:
+                output_args.append(to_snake_case(arg))
+        else:
+            output_args.append(arg)
+
+    keys = output_args[0::2]
+    vals = output_args[1::2]
+    return ["%s=%s" % (key, val) for (key, val) in zip(keys, vals)
+            if key in SUPPORTED_DATAFLOW_PIPELINE_ARGS]
+
+
+SUPPORTED_DATAFLOW_PIPELINE_ARGS = {
+    "--runner",
+    "--project",
+    "--staging_location",
+    "--zone",
+    "--region",
+    "--temp_location",
+    "--num_workers",
+    "--autoscaling_algorithm",
+    "--max_num_workers",
+    "--network",
+    "--subnetwork",
+    "--disk_size_gb",
+    "--worker_machine_type",
+    "--job_name",
+    "--worker_disk_type",
+    "--service_account_email",
+    "--requirements_file"
+    "--setup_file"
+}

--- a/tests/tfdv_test.py
+++ b/tests/tfdv_test.py
@@ -18,17 +18,21 @@
 
 import os
 import tempfile
+from os.path import join as pjoin
 from unittest import TestCase
 
 from examples.examples_utils import get_taxi_data_dir
-from spotify_tensorflow.tfx.tfdv import GenerateStats
+from spotify_tensorflow.tfx.tfdv import TfDataValidator
 
 
-class TFDVTest(TestCase):
+class TfDataValidatorTest(TestCase):
     def setUp(self):
         taxi_data = get_taxi_data_dir()
-        self.input_data_dir = taxi_data
-        self.stats_file = os.path.join(taxi_data, "stats.pb")
+        self.data_location = taxi_data
+        self.schema = pjoin(taxi_data, "chicago_taxi_schema.pbtxt")
+        self.schema_snapshot_path = pjoin(taxi_data, "schema_snapshot.pb")
+        self.stats_file = pjoin(taxi_data, "stats.pb")
+        self.anomalies_path = pjoin(self.data_location, "anomalies.pb")
         tmp_dir = tempfile.mkdtemp()
         self.pipeline_args = [
             "--temp_location=%s" % tmp_dir,
@@ -36,9 +40,23 @@ class TFDVTest(TestCase):
             "--runner=DirectRunner"
         ]
 
-    def test_generate_stats(self):
-        GenerateStats(self.input_data_dir).run(self.pipeline_args)
+    def test_write_stats_and_schema(self):
+        TfDataValidator(self.schema, self.data_location).write_stats_and_schema(self.pipeline_args)
         self.assertTrue(os.path.exists(self.stats_file))
+        self.assertTrue(os.path.exists(self.schema_snapshot_path))
+
+    def test_validate_stats_against_schema(self):
+        validator = TfDataValidator(self.schema, self.data_location)
+        validator.write_stats(self.pipeline_args)
+        self.assertTrue(os.path.exists(self.stats_file))
+        has_no_anomalies = validator.validate_stats_against_schema()
+        self.assertFalse(has_no_anomalies)
+        self.assertTrue(os.path.exists(self.anomalies_path))
 
     def tearDown(self):
-        os.remove(self.stats_file)
+        if os.path.exists(self.stats_file):
+            os.remove(self.stats_file)
+        if os.path.exists(self.schema_snapshot_path):
+            os.remove(self.schema_snapshot_path)
+        if os.path.exists(self.anomalies_path):
+            os.remove(self.anomalies_path)

--- a/tests/tfx_utils_test.py
+++ b/tests/tfx_utils_test.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017-2019 Spotify AB.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from unittest import TestCase
+
+from spotify_tensorflow.tfx.utils import clean_up_pipeline_args
+
+
+class TFXUtilsTest(TestCase):
+    def test_clean_up_pipeline_args(self):
+        pipeline_args = ["--project=1", "--tempLocation=gs://tmp", "--jobName", "test", "--extra=1"]
+        expected = ["--project=1", "--temp_location=gs://tmp", "--job_name=test"]
+        self.assertEqual(clean_up_pipeline_args(pipeline_args), expected)


### PR DESCRIPTION
Took over  TfDataValidator from @andrewsmartin's branch and added GenerateStats functionality into it, so TfDataValidator has the following functionalities now:
- write_stats (will need it for canonical schema initialization)
- write_stats_and_schema
- validate_stats_against_schema
- upload_schema
- upload_anomalies

