### PR TITLE
Bump tensorflow version to 1.13.0rc1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,21 +22,6 @@ jobs:
     steps:
       - tox: {env: "lint"}
 
-  test-tf19:
-    executor: tox
-    steps:
-      - tox: {env: "test-tf19"}
-
-  test-tf111:
-    executor: tox
-    steps:
-      - tox: {env: "test-tf111"}
-
-  test-tf112:
-    executor: tox
-    steps:
-      - tox: {env: "test-tf112"}
-
   test:
     executor: tox
     steps:
@@ -62,9 +47,6 @@ workflows:
   test:
     jobs:
       - lint
-      - test-tf19
-      - test-tf111
-      - test-tf112
       - test
       - examples
       - mypy

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ numpy>=1.14.0,<2.0.0
 oauth2client<4.0.0
 pandas>=0.22.0,<1.0.0
 six>=1.11.0,<2.0.0
-tensorflow==1.9.0; python_version=='2.7'
-tensorflow-transform==0.9.0; python_version=='2.7'
-tensorflow-data-validation==0.9.0; python_version=='2.7'
+tensorflow==1.13.0rc1; python_version=='2.7'
+tensorflow-transform==0.11.0; python_version=='2.7'
+tensorflow-data-validation==0.11.0; python_version=='2.7'
 tensorflow_metadata==0.9.0
 typing>=3.6.4,<4.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -10,32 +10,7 @@ commands =
   nosetests -vv
 extras =
   testing
-  tfdv
   luigi
-
-[testenv:test-tf19]
-commands =
-  pip install --quiet tensorflow==1.9.0
-  {[testenv]commands}
-
-[testenv:test-tf110]
-commands =
-  pip install --quiet tensorflow==1.10.0
-  {[testenv]commands}
-
-[testenv:test-tf111]
-commands =
-  pip install --quiet tensorflow==1.11.0
-  /usr/bin/find . -name "*.pyc" -delete
-  python -c "import tensorflow as tf; print tf.__version__"
-  {toxinidir}/bin/run-isolated-tests
-
-[testenv:test-tf112]
-commands =
-  pip install --quiet tensorflow==1.12.0
-  /usr/bin/find . -name "*.pyc" -delete
-  python -c "import tensorflow as tf; print tf.__version__"
-  {toxinidir}/bin/run-isolated-tests
 
 [testenv:lint]
 extras =
@@ -48,7 +23,6 @@ commands =
 [testenv:examples]
 extras =
   examples
-  tfdv
 commands =
   {toxinidir}/bin/run-examples
 


### PR DESCRIPTION
tensorflow 1.13 RC is out. It fixed the eager execution bug which caused our dataset api tests to fail. Meanwhile, we can also bump the tfx version to 1.11.0 now.

P.S. @brianmartin @andrewsmartin do we still need multiple test envs for different versions of tensorflow? It seems an overkill if we only support one set of versions in prod. 