### PR TITLE
Python 3 support (for #176)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,15 +22,25 @@ jobs:
     steps:
       - tox: {env: "lint"}
 
-  test:
+  test-py27:
     executor: tox
     steps:
-      - tox: {env: "test,upload-coverage"}
+      - tox: {env: "test-py27,upload-coverage"}
 
-  examples:
+  test-py35:
     executor: tox
     steps:
-      - tox: {env: "examples"}
+      - tox: {env: "test-py35"}
+
+  examples-py27:
+    executor: tox
+    steps:
+      - tox: {env: "examples-py27"}
+
+  examples-py35:
+    executor: tox
+    steps:
+      - tox: {env: "examples-py35"}
 
   mypy:
     executor: tox
@@ -47,7 +57,9 @@ workflows:
   test:
     jobs:
       - lint
-      - test
-      - examples
+      - test-py27
+      - test-py35
+      - examples-py27
+      - examples-py35
       - mypy
       - license

--- a/README.md
+++ b/README.md
@@ -49,10 +49,12 @@ To see all `testenv`'s:
 $ tox -l
 mypy
 lint
-examples
-test-tf18
-test-tf19
-test
+examples-py27
+examples-py35
+test-py27
+test-py35
+upload-coverage
+license
 ```
 
 To run the tests:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ numpy>=1.14.0,<2.0.0
 oauth2client<4.0.0
 pandas>=0.22.0,<1.0.0
 six>=1.11.0,<2.0.0
-tensorflow==1.13.1; python_version=='2.7'
-tensorflow-transform==0.12.0; python_version=='2.7'
-tensorflow-data-validation==0.12.0; python_version=='2.7'
-tensorflow_metadata==0.12.1
+tensorflow==1.13.1
+tensorflow-transform==0.13.0
+tensorflow-data-validation==0.13.1
+tensorflow_metadata==0.13.0
 typing>=3.6.4,<4.0.0

--- a/tests/example_decoders_test.py
+++ b/tests/example_decoders_test.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from __future__ import unicode_literals
+
 import json
 
 import tensorflow as tf
@@ -41,8 +43,8 @@ class ExampleDecodersTest(tf.test.TestCase):
                     value { float_list { value: [ 1.0, 2.0, 3.0, 4.0 ] } } }
           feature { key: "varlen_feature_2"
                     value { bytes_list { value: [ 'female' ] } } }
-          feature { key: "value" value { float_list { value: [ 12.0, 20.0 ] } } }
-          feature { key: "idx" value { int64_list { value: [ 1, 4 ] } } }
+          feature { key: "sparse_feature_value" value { float_list { value: [ 12.0, 20.0 ] } } }
+          feature { key: "sparse_feature_idx" value { int64_list { value: [ 1, 4 ] } } }
         }
         """, example)
         return example.SerializeToString()
@@ -56,7 +58,8 @@ class ExampleDecodersTest(tf.test.TestCase):
             "varlen_feature_2": tf.VarLenFeature(dtype=tf.string),
             "1d_vector_feature": tf.FixedLenFeature(shape=[1], dtype=tf.string),
             "2d_vector_feature": tf.FixedLenFeature(shape=[2, 2], dtype=tf.float32),
-            "sparse_feature": tf.SparseFeature("idx", "value", tf.float32, 10),
+            "sparse_feature": tf.SparseFeature("sparse_feature_idx", "sparse_feature_value",
+                                               tf.float32, 10),
         }
 
         dec = ExampleWithFeatureSpecDecoder(feature_spec)
@@ -69,7 +72,8 @@ class ExampleDecodersTest(tf.test.TestCase):
             "1d_vector_feature": ["this is a ,text"],
             "2d_vector_feature": [[1.0, 2.0], [3.0, 4.0]],
             "varlen_feature_2": ["female"],
-            "sparse_feature": [[1, 4], [12.0, 20.0]]
+            "sparse_feature_idx": [1, 4],
+            "sparse_feature_value": [12.0, 20.0],
         }
         self.assertEqual(actual_json, expected_decoded)
 
@@ -94,7 +98,7 @@ class ExampleDecodersTest(tf.test.TestCase):
                   ]
                 }
               },
-              "idx": {
+              "sparse_feature_idx": {
                 "int64List": {
                   "value": [
                     "1",
@@ -130,7 +134,7 @@ class ExampleDecodersTest(tf.test.TestCase):
                   ]
                 }
               },
-              "value": {
+              "sparse_feature_value": {
                 "floatList": {
                   "value": [
                     12.0,

--- a/tests/luigi_utils_test.py
+++ b/tests/luigi_utils_test.py
@@ -76,7 +76,7 @@ class LuigiUtilsTest(test.TestCase):
             get_uri(NotATarget())
             assert False
         except ValueError as e:
-            assert "Unknown input target type" in e.message
+            assert "Unknown input target type" in str(e)
 
     @staticmethod
     def test_run_with_logging():
@@ -178,4 +178,4 @@ unparseable
             fetch_tfdv_whl("0.11.0")
             assert False
         except Exception as e:
-            assert "Problem fetching package. Couldn't parse listing" in e.message
+            assert "Problem fetching package. Couldn't parse listing" in str(e)

--- a/tests/tf_schema_utils_test.py
+++ b/tests/tf_schema_utils_test.py
@@ -55,7 +55,7 @@ class TfSchemaUtilsTest(test.TestCase):
                     min_count: 1
                 }
             }
-        """
+        """.encode("utf-8")
 
         with NamedTemporaryFile() as f:
             f.write(schema_txt)

--- a/tests/tft_test.py
+++ b/tests/tft_test.py
@@ -50,7 +50,7 @@ class TFTransformTest(TestCase):
                     min_count: 1
                 }
             }
-        """
+        """.encode("utf-8")
 
     def setUp(self):
         self.schema_file = NamedTemporaryFile(delete=False)

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
 minversion = 3.3.0
-envlist = mypy,lint,examples,test,upload-coverage,license
+envlist = mypy,lint,examples-py{27,35},test-py{27, 35},upload-coverage,license
 
 [testenv]
-basepython = python2.7
 commands =
   /usr/bin/find . -name "*.pyc" -delete
-  python -c "import tensorflow as tf; print tf.__version__"
+  python -c "from __future__ import print_function; import tensorflow as tf; print(tf.__version__)"
   nosetests -vv
 extras =
   testing
@@ -20,14 +19,20 @@ commands =
   flake8 examples
   flake8 tests
 
-[testenv:examples]
+[testenv:examples-py27]
+extras =
+  examples
+commands =
+  {toxinidir}/bin/run-examples
+
+[testenv:examples-py35]
 extras =
   examples
 commands =
   {toxinidir}/bin/run-examples
 
 [testenv:mypy]
-basepython = python3.7
+basepython = python3.5
 extras =
 deps =
   mypy
@@ -36,6 +41,7 @@ commands =
   mypy tests
 
 [testenv:upload-coverage]
+basepython = python2.7
 extras =
 deps =
   codecov
@@ -45,6 +51,7 @@ commands =
   python -m codecov
 
 [testenv:license]
+basepython = python2.7
 extras =
 deps =
 commands =


### PR DESCRIPTION
This adds a tox env for testing against py35 (Beam is only supporting 3.5 for now).