### PR TITLE
Remove default output handling in tensorflow task

### DIFF
--- a/spotify_tensorflow/luigi/tensorflow_task.py
+++ b/spotify_tensorflow/luigi/tensorflow_task.py
@@ -23,9 +23,7 @@ import logging
 import uuid
 
 import luigi
-from luigi.contrib.gcs import GCSFlagTarget
-from luigi.local_target import LocalTarget
-from spotify_tensorflow.luigi.utils import is_gcs_path, get_uri, run_with_logging
+from spotify_tensorflow.luigi.utils import get_uri, run_with_logging
 
 logger = logging.getLogger("luigi-interface")
 
@@ -91,26 +89,11 @@ class TensorFlowTask(luigi.Task):
         cmd = self._mk_cmd()
         logger.info("Running:\n```\n%s\n```", cmd)
         run_with_logging(cmd, logger)
-        logger.info("Training successful. Marking as done.")
-        self._success_hook()
+        logger.info("Training finished.")
 
-    def output(self):
-        """
-        Generate Target dynamically based on `self.get_job_dir()`.
-        """
-        job_dir = str(self.get_job_dir())
-        return GCSFlagTarget(job_dir) if is_gcs_path(job_dir) else LocalTarget(job_dir)
-
-    # TODO(rav): look into luigi hooks
-    def _success_hook(self):
-        success_file = self.get_job_dir().rstrip("/") + "/_SUCCESS"
-        if is_gcs_path(self.get_job_dir()):
-            from luigi.contrib.gcs import GCSClient
-            client = GCSClient()
-            client.put_string("", success_file)
-        else:
-            # assume local filesystem otherwise
-            open(success_file, "a").close()
+    def get_job_dir(self):
+        """Get job directory used to store snapshots, logs, final output and any other artifacts."""
+        return self.job_dir
 
     def _mk_cmd(self):
         cmd = ["gcloud", "ml-engine"]
@@ -126,10 +109,6 @@ class TensorFlowTask(luigi.Task):
 
         cmd.extend(self._get_job_args())
         return cmd
-
-    def get_job_dir(self):
-        """Get job directory used to store snapshots, logs, final output and any other artifacts."""
-        return self.job_dir
 
     def _mk_cloud_params(self):
         params = []

--- a/tests/tensorflow_task_test.py
+++ b/tests/tensorflow_task_test.py
@@ -17,13 +17,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-import os
-import tempfile
 from unittest import TestCase
-from subprocess import CalledProcessError
 
 import luigi
-from luigi import LocalTarget
 from spotify_tensorflow.luigi.tensorflow_task import TensorFlowTask
 from tests.test_utils import MockGCSTarget
 
@@ -97,44 +93,3 @@ class TensorflowTaskTest(TestCase):
         self.assertEquals(actual[:6], expected[:6])
         self.assertRegexpMatches(actual[6], expected[6])
         self.assertEquals(actual[7:], expected[7:])
-
-    def test_run_success(self):
-
-        tmp_dir_path = tempfile.mkdtemp()
-
-        class SuperDummyTask(DummyTask):
-
-            def _mk_cmd(self):
-                return ["echo", "hello"]
-
-            def requires(self):
-                return LocalTarget(tmp_dir_path)
-
-        task = SuperDummyTask(cloud=False,
-                              job_dir=tmp_dir_path,
-                              model_package_path="/path/to/package")
-        task.run()
-
-        assert os.path.exists(os.path.join(tmp_dir_path, "_SUCCESS"))
-
-    def test_run_fail(self):
-
-        tmp_dir_path = tempfile.mkdtemp()
-
-        class SuperDummyTask(DummyTask):
-
-            def _mk_cmd(self):
-                return ["cp", "some", "crap"]
-
-            def requires(self):
-                return LocalTarget(tmp_dir_path)
-
-        task = SuperDummyTask(cloud=False,
-                              job_dir=tmp_dir_path,
-                              model_package_path="/path/to/package")
-
-        try:
-            task.run()
-            assert False
-        except CalledProcessError:
-            assert not os.path.exists(os.path.join(tmp_dir_path, "_SUCCESS"))


### PR DESCRIPTION
We should remove this default output behavior and instead have users be explicit.