### PR TITLE
Allowing tensorflow to be pinned to higher version (1.14.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ oauth2client<4.0.0
 pandas>=0.22.0,<1.0.0
 six>=1.11.0,<2.0.0
 scikit-learn>=0.18,<0.21
-tensorflow==1.13.1
+tensorflow>=1.13.1,<2.0.0a0
 tfx==0.13.0
 typing>=3.6.4,<4.0.0


### PR DESCRIPTION
In order to use the `install_requires` argument in our `setup.py` to define stageable libraries for python beam tasks, we can't have any version conflicts. The fact that this pins to a specific patch version makes bumping tensorflow anywhere in our stack impossible. This PR makes it _slightly_ more flexible.

This issue [has been brought up before](https://github.com/spotify/spotify-tensorflow/issues/76) as well, FYI.