### PR TITLE
Use model_name_suffix in _get_job_name()

### DIFF
--- a/spotify_tensorflow/luigi/tensorflow_task.py
+++ b/spotify_tensorflow/luigi/tensorflow_task.py
@@ -151,8 +151,11 @@ class TensorFlowTask(luigi.Task):
         return args
 
     def _get_job_name(self):
-        job_name = "%s_%s_%s" % (getpass.getuser(), self.__class__.__name__,
-                                 str(uuid.uuid4()).replace("-", "_"))
+        job_name = "%s_%s_%s_%s" % (
+            getpass.getuser(),
+            self.__class__.__name__,
+            self.model_name_suffix,
+            str(uuid.uuid4()).replace("-", "_"))
         return job_name
 
     def _get_input_args(self):


### PR DESCRIPTION
Use `model_name_suffix` to be able to customize the job name. Very useful to distinguish similar runs.