### PR TITLE
Fix python3 dataflow naming

### DIFF
--- a/spotify_tensorflow/luigi/python_dataflow_task.py
+++ b/spotify_tensorflow/luigi/python_dataflow_task.py
@@ -103,7 +103,7 @@ class PythonDataflowTask(MixinNaiveBulkComplete, luigi.Task):
             # job_name must consist of only the characters [-a-z0-9]
             cls_name = self.__class__.__name__.replace("_", "-").lower()
             self.job_name = "{cls_name}-{timestamp}".format(cls_name=cls_name,
-                                                            timestamp=str(time.time())[:-3])
+                                                            timestamp=str(int(time.time())))
 
     def on_successful_run(self):
         """ Callback that gets called right after the dataflow job has finished successfully but

--- a/spotify_tensorflow/tfx/tfdv.py
+++ b/spotify_tensorflow/tfx/tfdv.py
@@ -151,7 +151,7 @@ def generate_statistics_from_tfrecord(pipeline_args,  # type: List[str]
 
     if all_options["job_name"] is None:
         gcloud_options = pipeline_options.view_as(GoogleCloudOptions)
-        gcloud_options.job_name = "generatestats-%s" % str(time.time())[:-3]
+        gcloud_options.job_name = "generatestats-%s" % str(int(time.time()))
 
     if all_options["setup_file"] is None:
         setup_file_path = create_setup_file()


### PR DESCRIPTION
In python 3, the time module gives more precision than in python 2, so naming a job with `time.time())[:-3]` does not work properly since the job name must consist of only the characters [-a-z0-9].

```python3
import time
time.time()
1566903551.618038
```
