### PR TITLE
Pin lib version in ephemeral TFDV setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ google-api-python-client>=1.5.4,<2.0
 numpy>=1.14.0,<2.0.0
 oauth2client<4.0.0
 pandas>=0.22.0,<1.0.0
+pbr
 six>=1.11.0,<2.0.0
 scikit-learn>=0.18,<0.21
 tensorflow>=1.14.0,<1.15

--- a/spotify_tensorflow/tfx/utils.py
+++ b/spotify_tensorflow/tfx/utils.py
@@ -39,7 +39,7 @@ def assert_not_empty_string(arg):
 
 
 def create_setup_file():
-    lib_version = VersionInfo('spotify-tensorflow').version_string()
+    lib_version = VersionInfo("spotify_tensorflow").version_string()
     contents_for_setup_file = """
     import setuptools
     

--- a/spotify_tensorflow/tfx/utils.py
+++ b/spotify_tensorflow/tfx/utils.py
@@ -16,11 +16,11 @@
 # under the License.
 #
 import os
-from pbr.version import VersionInfo
 import tempfile
 import textwrap
 from typing import Any  # noqa: F401
 
+from pbr.version import VersionInfo
 from spotify_tensorflow.luigi.utils import to_snake_case
 
 

--- a/spotify_tensorflow/tfx/utils.py
+++ b/spotify_tensorflow/tfx/utils.py
@@ -16,6 +16,7 @@
 # under the License.
 #
 import os
+from pbr.version import VersionInfo
 import tempfile
 import textwrap
 from typing import Any  # noqa: F401
@@ -38,6 +39,7 @@ def assert_not_empty_string(arg):
 
 
 def create_setup_file():
+    lib_version = VersionInfo('spotify-tensorflow').version_string()
     contents_for_setup_file = """
     import setuptools
     
@@ -46,9 +48,9 @@ def create_setup_file():
             name="spotify_tensorflow_dataflow",
             packages=setuptools.find_packages(),
             install_requires=[
-                "spotify-tensorflow"
+                "spotify-tensorflow=={version}"
         ])
-    """  # noqa: W293
+    """.format(version=lib_version)  # noqa: W293
     setup_file_path = os.path.join(tempfile.mkdtemp(), "setup.py")
     with open(setup_file_path, "w") as f:
         f.writelines(textwrap.dedent(contents_for_setup_file))


### PR DESCRIPTION
Some folks have internally been caught by an issue where their jobs started failing all of a sudden, because the ephemeral setup file we create for TFDV doesn't pin the lib version. This resulted in newer versions of tensorflow and beam being pulled in.

The only drawback with this is that it makes pbr a required transitive dependency which isn't ideal. But not the end of the world. In the future perhaps we should switch to using a tool like bumpversion for release management.

PTAL @sngahane @brianmartin @daikeshi 