### PR TITLE
Fix #71, remove non-ascii characters from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub license](https://img.shields.io/github/license/spotify/spotify-tensorflow.svg)](./LICENSE)
 [![PyPI version](https://badge.fury.io/py/spotify_tensorflow.svg)](https://badge.fury.io/py/spotify_tensorflow)
 
-## Raison d'être:
+## Purpose:
 
 Provide Spotify specific TensorFlow helpers.
 


### PR DESCRIPTION
With #71, previously we had this issue with local installs where the environment does not set the default encoding to be UTF-8. We were able to address this by setting `LANG=C.UTF8`, but with AI platform workers we do not have control over this. 

This PR avoids the issue altogether by removing non-ascii characters from the README (which get included in the description in `setup.cfg`.